### PR TITLE
use timestamp.toEpochMilli() instead of Instant

### DIFF
--- a/src/main/java/com/teragrep/jla_01/syslog/SyslogRecordTimestamp.java
+++ b/src/main/java/com/teragrep/jla_01/syslog/SyslogRecordTimestamp.java
@@ -34,6 +34,6 @@ public final class SyslogRecordTimestamp implements SyslogRecord {
 
     @Override
     public SyslogMessage getRecord() {
-        return syslogRecord.getRecord().withTimestamp(timestamp);
+        return syslogRecord.getRecord().withTimestamp(timestamp.toEpochMilli());
     }
 }

--- a/src/test/java/com/teragrep/jla_01/RlpLogbackAppenderTest.java
+++ b/src/test/java/com/teragrep/jla_01/RlpLogbackAppenderTest.java
@@ -97,6 +97,11 @@ public class RlpLogbackAppenderTest {
 
 			Assertions.assertEquals("localhost", rfc5424Frame.hostname.toString());
 			Assertions.assertEquals("appName", rfc5424Frame.appName.toString());
+
+			Pattern timestampPattern = Pattern.compile("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{3}Z");
+
+			Assertions.assertTrue(timestampPattern.matcher(rfc5424Frame.timestamp.toString()).matches());
+
 			Assertions.assertEquals("DEBUG logger - "+testPayload+"\n", rfc5424Frame.msg.toString());
 		}
 


### PR DESCRIPTION
use timestamp.toEpochMilli() instead of Instant to avoid https://github.com/teragrep/rlo_14/issues/10